### PR TITLE
Haskell nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,12 @@ let
     # the haskell.nix functionality itself as an overlay.
     haskellNix.nixpkgsArgs;
 in pkgs.haskell-nix.project {
+  branchMap = {
+    "https://github.com/brendanhay/amazonka.git" = {
+      e64638ae16dc6d549d6e7c21262245e29761ede7 = "main";
+    };
+  };
+
   # 'cleanGit' cleans a source directory based on the files known by git
   src = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "haskell-nix-project";

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
     # haskell.nix provides access to the nixpkgs pins which are used by our CI,
     # hence you will be more likely to get cache hits when using these.
     # But you can also just use your own, e.g. '<nixpkgs>'.
-    haskellNix.sources.nixpkgs-2105
+    haskellNix.sources.nixpkgs-unstable
     # These arguments passed to nixpkgs, include some patches and also
     # the haskell.nix functionality itself as an overlay.
     haskellNix.nixpkgsArgs;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4e100b2ad96c221a78580701aa0a5a4f48f49130",
-        "sha256": "01b08ih2f10535vcf5gpq8d7j374szaganlyh9k2i3m7phcdlgjz",
+        "rev": "986a65b3974051baa3c6b029b58877772c60a71e",
+        "sha256": "0hxbs66a1i666z67iv0yk7yk6i2inijlzx9kijlb7mq3g7ykffcv",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/4e100b2ad96c221a78580701aa0a5a4f48f49130.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/986a65b3974051baa3c6b029b58877772c60a71e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
Massively improves cache hit rate, and tells haskell.nix which branch to find the amazonka commit on.